### PR TITLE
fix doc errors inside huffman & lz

### DIFF
--- a/crates/sourisdb/src/types/binary/lz.rs
+++ b/crates/sourisdb/src/types/binary/lz.rs
@@ -26,9 +26,9 @@ pub fn lz(input: &[u8]) -> Vec<u8> {
 ///Decompresses LZ compressed data
 ///
 /// # Errors
-/// - [`IntegerSerError`] if we cannot deserialise an integer
+/// - [`crate::types::integer::IntegerSerError`] if we cannot deserialise an integer
 /// - [`BinarySerError::NotEnoughBytes`] if there aren't enough bytes
-/// - [`DecompressError`] if we fail to decompress the bytes
+/// - [`lz4_flex::block::DecompressError`] if we fail to decompress the bytes
 pub fn un_lz(cursor: &mut Cursor<u8>) -> Result<Vec<u8>, BinarySerError> {
     let input_len: usize = Integer::deser(SignedState::Unsigned, cursor)?.try_into()?;
     if input_len == 0 {

--- a/crates/sourisdb/src/utilities/huffman.rs
+++ b/crates/sourisdb/src/utilities/huffman.rs
@@ -525,10 +525,12 @@ impl Huffman<char> {
         self.root.ser()
     }
 
-    ///Deserialise a [`Cursor`] into a [`Huffman`] using [`Node::deser`]
+    ///Deserialise a [`Cursor`] into a [`Huffman`].
     ///
-    /// ## Errors
-    /// See [`Node::deser`].
+    /// # Errors
+    /// - [`HuffmanSerError::NotEnoughBytes`] if there aren't enough bytes.
+    /// - [`IntegerSerError`] if there is an error deserialising one of the [`Integer`]s.
+    /// - [`HuffmanSerError::InvalidCharacter`] if we find an invalid character. 
     pub fn deser(bytes: &mut Cursor<u8>) -> Result<Self, HuffmanSerError> {
         let root = Node::deser(bytes)?;
 


### PR DESCRIPTION
yet again, forgetting which branch I was in

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced clarity of error handling in the `un_lz` and `deser` methods through updated documentation comments.
	- Improved readability of comments for the `Huffman` struct's `deser` method.
- **Bug Fixes**
	- Refined input handling in the `lz` function to return serialized size for empty input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->